### PR TITLE
`[Exiled::API]` Helper prefab system

### DIFF
--- a/Exiled.API/Enums/PrefabType.cs
+++ b/Exiled.API/Enums/PrefabType.cs
@@ -15,7 +15,7 @@ namespace Exiled.API.Enums
     public enum PrefabType
     {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable SA1602
+#pragma warning disable SA1602 // Enumeration items should be documented
         [Prefab(1883254029, "Player")]
         Player,
 

--- a/Exiled.API/Enums/PrefabType.cs
+++ b/Exiled.API/Enums/PrefabType.cs
@@ -7,14 +7,271 @@
 
 namespace Exiled.API.Enums
 {
+    using Exiled.API.Features.Attributes;
+
     /// <summary>
     /// Type of prefab.
     /// </summary>
     public enum PrefabType
     {
-        /// <summary>
-        /// Used for <see cref="Features.Workstation"/>.
-        /// </summary>
-        Workstation,
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1602
+        [Prefab(1883254029, "Player")]
+        Player,
+
+        [Prefab(2295511789, "EZ BreakableDoor")]
+        EZBreakableDoor,
+
+        [Prefab(2295511789, "HCZ BreakableDoor")]
+        HCZBreakableDoor,
+
+        [Prefab(3038351124, "LCZ BreakableDoor")]
+        LCZBreakableDoor,
+
+        [Prefab(1704345398, "sportTargetPrefab")]
+        SportTarget,
+
+        [Prefab(858699872, "dboyTargetPrefab")]
+        DBoyTarget,
+
+        [Prefab(3613149668, "binaryTargetPrefab")]
+        BinaryTarget,
+
+        [Prefab(1306864341, "TantrumObj")]
+        TantrumObj,
+
+        [Prefab(1321952889, "PrimitiveObjectToy")]
+        PrimitiveObjectToy,
+
+        [Prefab(3956448839, "LightSourceToy")]
+        LightSourceToy,
+
+        [Prefab(2672653014, "RegularKeycardPickup")]
+        RegularKeycardPickup,
+
+        [Prefab(335436768, "ChaosKeycardPickup")]
+        ChaosKeycardPickup,
+
+        [Prefab(248357067, "RadioPickup")]
+        RadioPickup,
+
+        [Prefab(1925130715, "Com15Pickup")]
+        Com15Pickup,
+
+        [Prefab(2808038258, "MedkitPickup")]
+        MedkitPickup,
+
+        [Prefab(2606539874, "FlashlightPickup")]
+        FlashlightPickup,
+
+        [Prefab(2974277164, "MicroHidPickup")]
+        MicroHidPickup,
+
+        [Prefab(1367360155, "SCP500Pickup")]
+        SCP500Pickup,
+
+        [Prefab(689511071, "SCP207Pickup")]
+        SCP207Pickup,
+
+        [Prefab(4056235189, "Ammo12gaPickup")]
+        Ammo12gaPickup,
+
+        [Prefab(212068596, "E11SRPickup")]
+        E11SRPickup,
+
+        [Prefab(1982658896, "CrossvecPickup")]
+        CrossvecPickup,
+
+        [Prefab(2474630775, "Ammo556mmPickup")]
+        Ammo556mmPickup,
+
+        [Prefab(3462306180, "Fsp9Pickup")]
+        Fsp9Pickup,
+
+        [Prefab(2405374689, "LogicerPickup")]
+        LogicerPickup,
+
+        [Prefab(1273232029, "HegPickup")]
+        HegPickup,
+
+        [Prefab(3871663704, "FlashbangPickup")]
+        FlashbangPickup,
+
+        [Prefab(1499866827, "Ammo44calPickup")]
+        Ammo44calPickup,
+
+        [Prefab(3685499023, "Ammo762mmPickup")]
+        Ammo762mmPickup,
+
+        [Prefab(2344368365, "Ammo9mmPickup")]
+        Ammo9mmPickup,
+
+        [Prefab(1749039070, "Com18Pickup")]
+        Com18Pickup,
+
+        [Prefab(3525743409, "Scp018Projectile")]
+        Scp018Projectile,
+
+        [Prefab(3711531185, "SCP268Pickup")]
+        SCP268Pickup,
+
+        [Prefab(1573779433, "AdrenalinePrefab")]
+        AdrenalinePrefab,
+
+        [Prefab(3124923193, "PainkillersPickup")]
+        PainkillersPickup,
+
+        [Prefab(3134959991, "CoinPickup")]
+        CoinPickup,
+
+        [Prefab(941440279, "Light Armor Pickup")]
+        LightArmorPickup,
+
+        [Prefab(3118088094, "Combat Armor Pickup")]
+        CombatArmorPickup,
+
+        [Prefab(3164421243, "Heavy Armor Pickup")]
+        HeavyArmorPickup,
+
+        [Prefab(1861159387, "RevolverPickup")]
+        RevolverPickup,
+
+        [Prefab(3814984482, "AkPickup")]
+        AkPickup,
+
+        [Prefab(3180035653, "ShotgunPickup")]
+        ShotgunPickup,
+
+        [Prefab(464602874, "Scp330Pickup")]
+        Scp330Pickup,
+
+        [Prefab(1983050408, "Scp2176Projectile")]
+        Scp2176Projectile,
+
+        [Prefab(2088018000, "SCP244APickup Variant")]
+        SCP244APickup,
+
+        [Prefab(3030062014, "SCP244BPickup Variant")]
+        SCP244BPickup,
+
+        [Prefab(2702950243, "SCP1853Pickup")]
+        SCP1853Pickup,
+
+        [Prefab(3881162440, "DisruptorPickup")]
+        DisruptorPickup,
+
+        [Prefab(504857316, "Com45Pickup")]
+        Com45Pickup,
+
+        [Prefab(303271247, "SCP1576Pickup")]
+        SCP1576Pickup,
+
+        [Prefab(2915316078, "JailbirdPickup")]
+        JailbirdPickup,
+
+        [Prefab(1209253563, "AntiSCP207Pickup")]
+        AntiSCP207Pickup,
+
+        [Prefab(2216560136, "FRMG0Pickup")]
+        FRMG0Pickup,
+
+        [Prefab(74988289, "A7Pickup")]
+        A7Pickup,
+
+        [Prefab(3532394942, "LanternPickup")]
+        LanternPickup,
+
+        [Prefab(825024811, "Amnestic Cloud Hazard")]
+        AmnesticCloudHazard,
+
+        [Prefab(2286635216, "Scp018PedestalStructure Variant")]
+        Scp018PedestalStructure,
+
+        [Prefab(664776131, "Scp207PedestalStructure Variant")]
+        Scp207PedestalStructure,
+
+        [Prefab(3724306703, "Scp244PedestalStructure Variant")]
+        Scp244PedestalStructure,
+
+        [Prefab(3849573771, "Scp268PedestalStructure Variant")]
+        Scp268PedestalStructure,
+
+        [Prefab(373821065, "Scp500PedestalStructure Variant")]
+        Scp500PedestalStructure,
+
+        [Prefab(3962534659, "Scp1853PedestalStructure Variant")]
+        Scp1853PedestalStructure,
+
+        [Prefab(3578915554, "Scp2176PedestalStructure Variant")]
+        Scp2176PedestalStructure,
+
+        [Prefab(3372339835, "Scp1576PedestalStructure Variant")]
+        Scp1576PedestalStructure,
+
+        [Prefab(2830750618, "LargeGunLockerStructure")]
+        LargeGunLockerStructure,
+
+        [Prefab(3352879624, "RifleRackStructure")]
+        RifleRackStructure,
+
+        [Prefab(1964083310, "MiscLocker")]
+        MiscLocker,
+
+        [Prefab(2724603877, "GeneratorStructure")]
+        GeneratorStructure,
+
+        [Prefab(1783091262, "Spawnable Work Station Structure")]
+        WorkstationStructure,
+
+        [Prefab(4040822781, "RegularMedkitStructure")]
+        RegularMedkitStructure,
+
+        [Prefab(2525847434, "AdrenalineMedkitStructure")]
+        AdrenalineMedkitStructure,
+
+        [Prefab(427210814, "HegProjectile")]
+        HegProjectile,
+
+        [Prefab(2409733045, "FlashbangProjectile")]
+        FlashbangProjectile,
+
+        [Prefab(1062458989, "SCP-173_Ragdoll")]
+        Scp173Ragdoll,
+
+        [Prefab(1951328980, "Ragdoll_1")]
+        Ragdoll1,
+
+        [Prefab(992490681, "SCP-106_Ragdoll")]
+        Scp106Ragdoll,
+
+        [Prefab(3219675689, "Ragdoll_4")]
+        Ragdoll4,
+
+        [Prefab(417388851, "Ragdoll_7")]
+        Ragdoll7,
+
+        [Prefab(3185790062, "Ragdoll_6")]
+        Ragdoll6,
+
+        [Prefab(2567420661, "Ragdoll_8")]
+        Ragdoll8,
+
+        [Prefab(149379640, "SCP-096_Ragdoll")]
+        Scp096Ragdoll,
+
+        [Prefab(1862774274, "Ragdoll_10")]
+        Ragdoll10,
+
+        [Prefab(2710373253, "Ragdoll_Tut")]
+        RagdollTutorial,
+
+        [Prefab(1389252654, "Ragdoll_12")]
+        Ragdoll12,
+
+        [Prefab(3175759689, "SCP-939_Ragdoll")]
+        Scp939Ragdoll,
+
+        [Prefab(3721192489, "Scp3114_Ragdoll")]
+        Scp3114Ragdoll,
     }
 }

--- a/Exiled.API/Features/Attributes/PrefabAttribute.cs
+++ b/Exiled.API/Features/Attributes/PrefabAttribute.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="PrefabAttribute.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Features.Attributes
+{
+    using System;
+
+    /// <inheritdoc />
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public class PrefabAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrefabAttribute"/> class.
+        /// </summary>
+        /// <param name="assetId"><inheritdoc cref="AssetId"/></param>
+        /// <param name="name"><inheritdoc cref="Name"/></param>
+        public PrefabAttribute(uint assetId, string name)
+        {
+            AssetId = assetId;
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the prefab's asset id.
+        /// </summary>
+        public uint AssetId { get; }
+
+        /// <summary>
+        /// Gets the prefab's name.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/Exiled.API/Features/PrefabHelper.cs
+++ b/Exiled.API/Features/PrefabHelper.cs
@@ -7,11 +7,14 @@
 
 namespace Exiled.API.Features
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Reflection;
 
     using Exiled.API.Enums;
+    using Exiled.API.Features.Attributes;
     using Mirror;
     using UnityEngine;
 
@@ -20,21 +23,63 @@ namespace Exiled.API.Features
     /// </summary>
     public static class PrefabHelper
     {
-        private static Dictionary<PrefabType, GameObject> stored = new();
+        private static readonly Dictionary<PrefabType, GameObject> Stored = new();
 
         /// <summary>
         /// Gets a dictionary of <see cref="PrefabType"/> to <see cref="GameObject"/>.
         /// </summary>
-        public static ReadOnlyDictionary<PrefabType, GameObject> PrefabToGameObject => new(stored);
+        public static ReadOnlyDictionary<PrefabType, GameObject> PrefabToGameObject => new(Stored);
 
         /// <summary>
-        /// Loads the prefabs.
+        /// Gets the prefab attribute of a prefab type.
+        /// </summary>
+        /// <param name="prefabType">The prefab type.</param>
+        /// <returns>The <see cref="PrefabAttribute" />.</returns>
+        public static PrefabAttribute GetPrefabAttribute(this PrefabType prefabType)
+        {
+            Type type = prefabType.GetType();
+            return type.GetField(Enum.GetName(type, prefabType)).GetCustomAttribute<PrefabAttribute>();
+        }
+
+        /// <summary>
+        /// Tries to get a <see cref="GameObject"/> of the specified <see cref="PrefabType"/>.
+        /// </summary>
+        /// <param name="prefabType">The prefab type.</param>
+        /// <param name="prefab">The corresponding <see cref="GameObject"/>.</param>
+        /// <returns><see langword="true"/> if a <see cref="GameObject"/> of the specified <see cref="PrefabType"/> was found; otherwise, <see langword="false"/>.</returns>
+        public static bool TryGetGameObject(PrefabType prefabType, out GameObject prefab)
+        {
+            return Stored.TryGetValue(prefabType, out prefab);
+        }
+
+        /// <summary>
+        /// Spawns a prefab on server.
+        /// </summary>
+        /// <param name="prefabType">The prefab type.</param>
+        /// <param name="position">The position to spawn the prefab.</param>
+        /// <param name="rotation">The rotation of the prefab.</param>
+        /// <returns>The <see cref="GameObject"/> instantied.</returns>
+        public static GameObject Spawn(PrefabType prefabType, Vector3 position = default, Quaternion rotation = default)
+        {
+            if (!TryGetGameObject(prefabType, out GameObject gameObject))
+                return null;
+            GameObject newGameObject = UnityEngine.Object.Instantiate(gameObject, position, rotation);
+            NetworkServer.Spawn(newGameObject);
+            return newGameObject;
+        }
+
+        /// <summary>
+        /// Loads all prefabs.
         /// </summary>
         internal static void LoadPrefabs()
         {
-            stored.Clear();
+            Stored.Clear();
 
-            stored.Add(PrefabType.Workstation, NetworkClient.prefabs.Values.First(x => x.name.Contains("Work Station")));
+            foreach (PrefabType prefabType in Enum.GetValues(typeof(PrefabType)))
+            {
+                PrefabAttribute attribute = prefabType.GetPrefabAttribute();
+                Stored.Add(prefabType, NetworkClient.prefabs.FirstOrDefault(prefab => prefab.Key == attribute.AssetId || prefab.Value.name.Contains(attribute.Name)).Value);
+            }
         }
     }
 }


### PR DESCRIPTION
## Additions
- New attribute for prefabs
- Add all prefabs to the PrefabType enum and their attributes
- `PrefabHelper.GetPrefabAttribute(this PrefabType)` - returns prefab's attribute
- `PrefabHelper.TryGetGameObject(PrefabType, out GameObject)` - tries to get the game object of a specified `PrefabType`
- `PrefabHelper.Spawn(PrefabType, Vector3, Quaternion)` - spawns the prefab on the server and returns `GameObject` instantied