### PR TITLE
Changes and additions to Prefab Helper system

### DIFF
--- a/Exiled.API/Features/Generator.cs
+++ b/Exiled.API/Features/Generator.cs
@@ -16,10 +16,7 @@ namespace Exiled.API.Features
     using Exiled.API.Features.Core;
     using Exiled.API.Interfaces;
     using MapGeneration.Distributors;
-    using Mirror;
     using UnityEngine;
-
-    using Object = UnityEngine.Object;
 
     /// <summary>
     /// Wrapper class for <see cref="Scp079Generator"/>.
@@ -44,9 +41,14 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Gets the prefab.
+        /// Gets the prefab's type.
         /// </summary>
-        public static Scp079Generator Prefab => PrefabHelper.PrefabToGameObject[PrefabType.GeneratorStructure].GetComponent<Scp079Generator>();
+        public static PrefabType PrefabType => PrefabType.GeneratorStructure;
+
+        /// <summary>
+        /// Gets the prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Generator"/> which contains all the <see cref="Generator"/> instances.
@@ -232,14 +234,8 @@ namespace Exiled.API.Features
         /// <returns>The Generator that was spawned.</returns>
         public static Generator Spawn(Vector3 position, Quaternion rotation = default)
         {
-            Scp079Generator obj = Object.Instantiate(Prefab).GetComponent<Scp079Generator>();
-            Generator gen = Get(obj);
-
-            gen.Position = position;
-            gen.Rotation = rotation;
-
-            NetworkServer.Spawn(gen.GameObject);
-            return gen;
+            Scp079Generator generator = PrefabHelper.Spawn<Scp079Generator>(PrefabType, position, rotation);
+            return Get(generator);
         }
 
         /// <summary>

--- a/Exiled.API/Features/Hazards/AmnesticCloudHazard.cs
+++ b/Exiled.API/Features/Hazards/AmnesticCloudHazard.cs
@@ -33,9 +33,14 @@ namespace Exiled.API.Features.Hazards
         }
 
         /// <summary>
-        /// Gets the amnestic cloud prefab.
+        /// Gets the amnestic cloud prefab's type.
         /// </summary>
-        public static AmnesticCloudHazard Prefab => PrefabHelper.PrefabToGameObject[PrefabType.AmnesticCloudHazard].GetComponent<AmnesticCloudHazard>();
+        public static PrefabType PrefabType => PrefabType.AmnesticCloudHazard;
+
+        /// <summary>
+        /// Gets the amnestic cloud prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <inheritdoc cref="Hazard.Base"/>
         public new Scp939AmnesticCloudInstance Base { get; }

--- a/Exiled.API/Features/Hazards/TantrumHazard.cs
+++ b/Exiled.API/Features/Hazards/TantrumHazard.cs
@@ -36,9 +36,14 @@ namespace Exiled.API.Features.Hazards
         }
 
         /// <summary>
-        /// Gets the tantrum prefab.
+        /// Gets the tantrum prefab's type.
         /// </summary>
-        public static TantrumEnvironmentalHazard Prefab => PrefabHelper.PrefabToGameObject[PrefabType.TantrumObj].GetComponent<TantrumEnvironmentalHazard>();
+        public static PrefabType PrefabType => PrefabType.TantrumObj;
+
+        /// <summary>
+        /// Gets the tantrum cloud prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <summary>
         /// Gets the <see cref="TantrumEnvironmentalHazard"/>.
@@ -84,7 +89,7 @@ namespace Exiled.API.Features.Hazards
         /// <returns>The <see cref="TantrumHazard"/> instance.</returns>
         public static TantrumHazard CreateAndSpawn(Vector3 position, bool isActive = true)
         {
-            TantrumEnvironmentalHazard tantrum = Object.Instantiate(Prefab);
+            TantrumEnvironmentalHazard tantrum = PrefabHelper.Spawn<TantrumEnvironmentalHazard>(PrefabType);
 
             if (!isActive)
                 tantrum.SynchronizedPosition = new RelativePosition(position);
@@ -92,8 +97,6 @@ namespace Exiled.API.Features.Hazards
                 tantrum.SynchronizedPosition = new RelativePosition(position + (Vector3.up * 0.25f));
 
             tantrum._destroyed = !isActive;
-
-            NetworkServer.Spawn(tantrum.gameObject);
 
             return Get(tantrum) as TantrumHazard;
         }

--- a/Exiled.API/Features/PrefabHelper.cs
+++ b/Exiled.API/Features/PrefabHelper.cs
@@ -58,6 +58,24 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Spawns a prefab on server.
+        /// </summary>
+        /// <param name="prefabType">The prefab type.</param>
+        /// <param name="position">The position to spawn the prefab.</param>
+        /// <param name="rotation">The rotation of the prefab.</param>
+        /// <typeparam name="T">The <see cref="Component"/> type.</typeparam>
+        /// <returns>The <see cref="Component"/> instantied.</returns>
+        public static T Spawn<T>(PrefabType prefabType, Vector3 position = default, Quaternion rotation = default)
+            where T : Component
+        {
+            if (!Stored.TryGetValue(prefabType, out GameObject gameObject) || !gameObject.TryGetComponent(out T component))
+                return null;
+            T obj = UnityEngine.Object.Instantiate(component, position, rotation);
+            NetworkServer.Spawn(obj.gameObject);
+            return obj;
+        }
+
+        /// <summary>
         /// Loads all prefabs.
         /// </summary>
         internal static void LoadPrefabs()

--- a/Exiled.API/Features/Toys/Light.cs
+++ b/Exiled.API/Features/Toys/Light.cs
@@ -32,9 +32,14 @@ namespace Exiled.API.Features.Toys
         }
 
         /// <summary>
-        /// Gets the prefab.
+        /// Gets the light prefab's type.
         /// </summary>
-        public static LightSourceToy Prefab => PrefabHelper.PrefabToGameObject[PrefabType.LightSourceToy].GetComponent<LightSourceToy>();
+        public static PrefabType PrefabType => PrefabType.LightSourceToy;
+
+        /// <summary>
+        /// Gets the light prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <summary>
         /// Gets the base <see cref="LightSourceToy"/>.
@@ -99,7 +104,7 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="Light"/>.</returns>
         public static Light Create(Vector3? position /*= null*/, Vector3? rotation /*= null*/, Vector3? scale /*= null*/, bool spawn /*= true*/, Color? color /*= null*/)
         {
-            Light light = new(UnityEngine.Object.Instantiate(Prefab));
+            Light light = new(Object.Instantiate(PrefabObject.GetComponent<LightSourceToy>()));
 
             Transform transform = light.Base.transform;
             transform.position = position ?? Vector3.zero;

--- a/Exiled.API/Features/Toys/Primitive.cs
+++ b/Exiled.API/Features/Toys/Primitive.cs
@@ -31,9 +31,14 @@ namespace Exiled.API.Features.Toys
             : base(toyAdminToyBase, AdminToyType.PrimitiveObject) => Base = toyAdminToyBase;
 
         /// <summary>
-        /// Gets the prefab.
+        /// Gets the light prefab's type.
         /// </summary>
-        public static PrimitiveObjectToy Prefab => PrefabHelper.PrefabToGameObject[PrefabType.PrimitiveObjectToy].GetComponent<PrimitiveObjectToy>();
+        public static PrefabType PrefabType => PrefabType.PrimitiveObjectToy;
+
+        /// <summary>
+        /// Gets the light prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <summary>
         /// Gets the base <see cref="PrimitiveObjectToy"/>.
@@ -119,7 +124,7 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="Primitive"/>.</returns>
         public static Primitive Create(Vector3? position /*= null*/, Vector3? rotation /*= null*/, Vector3? scale /*= null*/, bool spawn /*= true*/, Color? color /*= null*/)
         {
-            Primitive primitive = new(Object.Instantiate(Prefab));
+            Primitive primitive = new(Object.Instantiate(PrefabObject.GetComponent<PrimitiveObjectToy>()));
 
             Transform transform = primitive.Base.transform;
             transform.position = position ?? Vector3.zero;
@@ -147,7 +152,7 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="Primitive"/>.</returns>
         public static Primitive Create(PrimitiveType primitiveType /*= PrimitiveType.Sphere*/, Vector3? position /*= null*/, Vector3? rotation /*= null*/, Vector3? scale /*= null*/, bool spawn /*= true*/, Color? color /*= null*/)
         {
-            Primitive primitive = new(Object.Instantiate(Prefab));
+            Primitive primitive = new(Object.Instantiate(PrefabObject.GetComponent<PrimitiveObjectToy>()));
 
             Transform transform = primitive.Base.transform;
             transform.position = position ?? Vector3.zero;
@@ -177,7 +182,7 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="Primitive"/>.</returns>
         public static Primitive Create(PrimitiveType primitiveType /*= PrimitiveType.Sphere*/, PrimitiveFlags flags, Vector3? position /*= null*/, Vector3? rotation /*= null*/, Vector3? scale /*= null*/, bool spawn /*= true*/, Color? color /*= null*/)
         {
-            Primitive primitive = new(Object.Instantiate(Prefab));
+            Primitive primitive = new(Object.Instantiate(PrefabObject.GetComponent<PrimitiveObjectToy>()));
 
             primitive.AdminToyBase.transform.position = position ?? Vector3.zero;
             primitive.AdminToyBase.transform.eulerAngles = rotation ?? Vector3.zero;
@@ -201,7 +206,7 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="Primitive"/>.</returns>
         public static Primitive Create(PrimitiveSettings primitiveSettings)
         {
-            Primitive primitive = new(Object.Instantiate(Prefab));
+            Primitive primitive = new(Object.Instantiate(PrefabObject.GetComponent<PrimitiveObjectToy>()));
 
             Transform transform = primitive.Base.transform;
             transform.position = primitiveSettings.Position;

--- a/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -47,19 +47,34 @@ namespace Exiled.API.Features.Toys
         }
 
         /// <summary>
-        /// Gets the <see cref="ShootingTargetType.ClassD"/> prefab.
+        /// Gets the <see cref="ShootingTargetType.ClassD"/> prefab's type.
         /// </summary>
-        public static ShootingTarget DBoyTargetPrefab => PrefabHelper.PrefabToGameObject[PrefabType.DBoyTarget].GetComponent<ShootingTarget>();
+        public static PrefabType DBoyTargetPrefabType => PrefabType.DBoyTarget;
 
         /// <summary>
-        /// Gets the <see cref="ShootingTargetType.Binary"/> prefab.
+        /// Gets the <see cref="ShootingTargetType.ClassD"/> prefab's object.
         /// </summary>
-        public static ShootingTarget BinaryTargetPrefab => PrefabHelper.PrefabToGameObject[PrefabType.BinaryTarget].GetComponent<ShootingTarget>();
+        public static GameObject DBoyTargetPrefabObject => PrefabHelper.PrefabToGameObject[DBoyTargetPrefabType];
 
         /// <summary>
-        /// Gets the <see cref="ShootingTargetType.Sport"/> prefab.
+        /// Gets the <see cref="ShootingTargetType.Binary"/> prefab's type.
         /// </summary>
-        public static ShootingTarget SportTargetPrefab => PrefabHelper.PrefabToGameObject[PrefabType.SportTarget].GetComponent<ShootingTarget>();
+        public static PrefabType BinaryTargetPrefabType => PrefabType.BinaryTarget;
+
+        /// <summary>
+        /// Gets the <see cref="ShootingTargetType.Binary"/> prefab's object.
+        /// </summary>
+        public static GameObject BinaryTargetPrefabObject => PrefabHelper.PrefabToGameObject[BinaryTargetPrefabType];
+
+        /// <summary>
+        /// Gets the <see cref="ShootingTargetType.Sport"/> prefab's type.
+        /// </summary>
+        public static PrefabType SportTargetPrefabType => PrefabType.SportTarget;
+
+        /// <summary>
+        /// Gets the <see cref="ShootingTargetType.Sport"/> prefab's object.
+        /// </summary>
+        public static GameObject SportTargetPrefabObject => PrefabHelper.PrefabToGameObject[SportTargetPrefabType];
 
         /// <summary>
         /// Gets the base-game <see cref="ShootingTarget"/> for this target.
@@ -169,28 +184,12 @@ namespace Exiled.API.Features.Toys
         /// <returns>The new <see cref="ShootingTargetToy"/>.</returns>
         public static ShootingTargetToy Create(ShootingTargetType type, Vector3? position = null, Vector3? rotation = null, Vector3? scale = null, bool spawn = true)
         {
-            ShootingTargetToy shootingTargetToy;
-
-            switch (type)
+            ShootingTargetToy shootingTargetToy = type switch
             {
-                case ShootingTargetType.ClassD:
-                    {
-                        shootingTargetToy = new ShootingTargetToy(Object.Instantiate(DBoyTargetPrefab));
-                        break;
-                    }
-
-                case ShootingTargetType.Binary:
-                    {
-                        shootingTargetToy = new ShootingTargetToy(Object.Instantiate(BinaryTargetPrefab));
-                        break;
-                    }
-
-                default:
-                    {
-                        shootingTargetToy = new ShootingTargetToy(Object.Instantiate(SportTargetPrefab));
-                        break;
-                    }
-            }
+                ShootingTargetType.ClassD => new ShootingTargetToy(Object.Instantiate(DBoyTargetPrefabObject.GetComponent<ShootingTarget>())),
+                ShootingTargetType.Binary => new ShootingTargetToy(Object.Instantiate(BinaryTargetPrefabObject.GetComponent<ShootingTarget>())),
+                _ => new ShootingTargetToy(Object.Instantiate(SportTargetPrefabObject.GetComponent<ShootingTarget>()))
+            };
 
             Transform transform = shootingTargetToy.Base.transform;
             transform.position = position ?? Vector3.zero;

--- a/Exiled.API/Features/Workstation.cs
+++ b/Exiled.API/Features/Workstation.cs
@@ -49,9 +49,14 @@ namespace Exiled.API.Features
         public static new IReadOnlyCollection<Workstation> List => BaseToWrapper.Values;
 
         /// <summary>
-        /// Gets the Prefab of Workstation.
+        /// Gets the prefab's type.
         /// </summary>
-        public static WorkstationController Prefab => PrefabHelper.PrefabToGameObject[PrefabType.WorkstationStructure].GetComponent<WorkstationController>();
+        public static PrefabType PrefabType => PrefabType.WorkstationStructure;
+
+        /// <summary>
+        /// Gets the prefab's object.
+        /// </summary>
+        public static GameObject PrefabObject => PrefabHelper.PrefabToGameObject[PrefabType];
 
         /// <inheritdoc/>
         public WorkstationController Base { get; }
@@ -100,15 +105,8 @@ namespace Exiled.API.Features
         /// <returns>The Workstation that was spawned.</returns>
         public static Workstation Spawn(Vector3 position, Quaternion rotation = default)
         {
-            WorkstationController controller = Object.Instantiate(Prefab);
-            Workstation workstation = Get(controller);
-
-            workstation.Position = position;
-            workstation.Rotation = rotation;
-
-            NetworkServer.Spawn(controller.gameObject);
-
-            return workstation;
+            WorkstationController controller = PrefabHelper.Spawn<WorkstationController>(PrefabType, position, rotation);
+            return Get(controller);
         }
 
         /// <summary>


### PR DESCRIPTION
## Additions
- `PrefabHelper.Spawn<T>(PrefabType, Vector3, Quaternion)` - this method returns the T (Component) instantied
- `PrefabObject` (GameObject) and `PrefabType` (PrefabType)
## Changes
- Removed `Prefab` (Component) since prefab isn't just a component